### PR TITLE
Potential fix for code scanning alert no. 7: Uncontrolled process operation

### DIFF
--- a/unix.c
+++ b/unix.c
@@ -1,6 +1,8 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <sys/stat.h>
+#include <unistd.h>
  
 #define BUFSIZE 256
     
@@ -11,7 +13,10 @@ int main(int argc, char** argv) {
         fprintf(stderr, "Please provide the address of a file as an input.\n");
         return -1;
     }
-    char cmd[BUFSIZE] = "wc -c < ";
-    strcat(cmd, argv[1]);
-    system(cmd);
+    struct stat file_stat;
+    if (stat(argv[1], &file_stat) != 0) {
+        perror("stat");
+        return -1;
+    }
+    printf("File size: %lld bytes\n", (long long) file_stat.st_size);
 }


### PR DESCRIPTION
Potential fix for [https://github.com/HamidaMuhammad/New-Repository/security/code-scanning/7](https://github.com/HamidaMuhammad/New-Repository/security/code-scanning/7)

To fix the problem, we need to avoid directly passing user input to the `system` function. Instead, we should use a safer method to achieve the same functionality. One way to do this is by using the `stat` function to get the file size directly in the code, rather than relying on an external command. This approach eliminates the need to construct a command string and call `system`, thus removing the risk of command injection.

We will modify the code to use the `stat` function to get the file size and print it. This change will be made in the `main` function of the `unix.c` file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
