### PR TITLE
Potential fix for code scanning alert no. 6: Unbounded write

### DIFF
--- a/unix.c
+++ b/unix.c
@@ -12,6 +12,6 @@ int main(int argc, char** argv) {
         return -1;
     }
     char cmd[BUFSIZE] = "wc -c < ";
-    strcat(cmd, argv[1]);
+    strncat(cmd, argv[1], BUFSIZE - strlen(cmd) - 1);
     system(cmd);
 }


### PR DESCRIPTION
Potential fix for [https://github.com/HamidaMuhammad/New-Repository/security/code-scanning/6](https://github.com/HamidaMuhammad/New-Repository/security/code-scanning/6)

To fix the problem, we need to ensure that the concatenation of the command-line argument to the buffer does not exceed the buffer's size. We can achieve this by using the `strncat` function instead of `strcat`, which allows us to specify the maximum number of characters to concatenate. Additionally, we should ensure that the buffer is properly null-terminated.

The best way to fix the problem is to replace the `strcat` call with `strncat` and calculate the maximum number of characters to concatenate based on the buffer size and the length of the existing content in the buffer.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
